### PR TITLE
Zooming and Panning Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,55 @@
 
 Multiplayer Conway's Game of Life!
 
+## Installing Depenencies
+Conwayste depends on `SDL2`, `SDL2_Mixer` and `SDL2_Image`. We do plan on bundling these libraries with the binary at some point in the future, but for now you'll need to manually install them. Current verions needed are:
+
+* SDL2 v2.0.5
+* SDL2\_Mixer v2.0.1
+* SDL2\_Image v2.0.1
+
+Make sure your Rust is up to date!
+
+`rustup update`
+
+### Windows
+TBD...
+
+### Mac/Linux
+I used homebrew on Mac to accomplish these steps. 
+
+```
+brew install sdl2
+brew install sdl2_image 
+brew install sdl2_mixer --with-libvorbis
+```
+
+On Fedora you can use yum:
+
+```
+TBD
+```
+
+Debian stable only supports SDL2 v.2.0.4 so you'll need to compile SDL2 from source.
+If you're compiling from source it will be very similar.
+
+```
+TBD
+./configure --with-vorbis
+```
+
+And then add the libraries to your path. This step is necessary if cargo fails to link against theSDL2 libraries.
+ 
+Under Linux, I had to export `LD_LIBRARY_PATH`, but in Mac it was simply `LD_LIBRARY_PATH`.
+Homebrew will install the libraries to the Cellar. 
+```
+export LIBRARY_PATH="/usr/local/Cellar/sdl2_mixer/2.0.1/lib/:/usr/local/Cellar/sdl2_image/2.0.1_2/lib/:/usr/local/Cellar/sdl2/2.0.5/lib/"
+```
+
 ## Building
-**TODO: SDL and OpenGL development packages, etc.**
+
+**TODO: OpenGL development packages, etc.**
+
 ```
 cargo build
 ln -s ../resources target    # needed only for client

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Multiplayer Conway's Game of Life!
 ## Installing Depenencies
 Conwayste depends on `SDL2`, `SDL2_Mixer` and `SDL2_Image`. We do plan on bundling these libraries with the binary at some point in the future, but for now you'll need to manually install them. Current verions needed are:
 
-* SDL2 v2.0.5
-* SDL2\_Mixer v2.0.1
-* SDL2\_Image v2.0.1
+* `SDL2 v2.0.5`
+* `SDL2\_Mixer v2.0.1`
+* `SDL2\_Image v2.0.1`
 
-Make sure your Rust is up to date!
+Make sure your Rust is up to date! The easiest way is through rustup.
 
 `rustup update`
 
@@ -41,7 +41,7 @@ TBD
 
 And then add the libraries to your path. This step is necessary if cargo fails to link against theSDL2 libraries.
  
-Under Linux, I had to export `LD_LIBRARY_PATH`, but in Mac it was simply `LD_LIBRARY_PATH`.
+Under Linux, I had to export `$LD_LIBRARY_PATH`, but in Mac it was simply `$LIBRARY_PATH`.
 Homebrew will install the libraries to the Cellar. 
 ```
 export LIBRARY_PATH="/usr/local/Cellar/sdl2_mixer/2.0.1/lib/:/usr/local/Cellar/sdl2_image/2.0.1_2/lib/:/usr/local/Cellar/sdl2/2.0.5/lib/"
@@ -65,7 +65,7 @@ cargo run --bin server 0.0.0.0:9000
 ## Running the client
 
 ```
-cargo run --bin client 127.0.0.1:9000
+cargo run --bin client
 ```
 
 ## Hacking

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Multiplayer Conway's Game of Life!
 
 ## Installing Depenencies
-Conwayste depends on `SDL2`, `SDL2_Mixer` and `SDL2_Image`. We do plan on bundling these libraries with the binary at some point in the future, but for now you'll need to manually install them. Current verions needed are:
+Conwayste depends on `SDL2`, `SDL2_Mixer` and `SDL2_Image`. We do plan on bundling these libraries with the binary at some point in the future, but for now you'll need to manually install them. The versions needed are:
 
 * `SDL2 v2.0.5`
 * `SDL2\_Mixer v2.0.1`
@@ -17,7 +17,7 @@ Make sure your Rust is up to date! The easiest way is through rustup.
 TBD...
 
 ### Mac/Linux
-I used homebrew on Mac to accomplish these steps. 
+_Note: I used homebrew on Mac to accomplish these steps._
 
 ```
 brew install sdl2
@@ -32,20 +32,21 @@ TBD
 ```
 
 Debian stable only supports SDL2 v.2.0.4 so you'll need to compile SDL2 from source.
-If you're compiling from source it will be very similar.
+If you're compiling from source the steps will be very similar.
 
 ```
-TBD
+...
 ./configure --with-vorbis
 ```
 
 And then add the libraries to your path. This step is necessary if cargo fails to link against theSDL2 libraries.
  
-Under Linux, I had to export `$LD_LIBRARY_PATH`, but in Mac it was simply `$LIBRARY_PATH`.
+Under Linux, I had to export `$LD_LIBRARY_PATH`, but in Mac it was `$LIBRARY_PATH`.
 Homebrew will install the libraries to the Cellar. 
 ```
 export LIBRARY_PATH="/usr/local/Cellar/sdl2_mixer/2.0.1/lib/:/usr/local/Cellar/sdl2_image/2.0.1_2/lib/:/usr/local/Cellar/sdl2/2.0.5/lib/"
 ```
+I ended up adding these to my `~/.profile` .
 
 ## Building
 
@@ -53,7 +54,8 @@ export LIBRARY_PATH="/usr/local/Cellar/sdl2_mixer/2.0.1/lib/:/usr/local/Cellar/s
 
 ```
 cargo build
-ln -s ../resources target    # needed only for client
+ln -s ../resources target    # Needed only for the Client. 
+                             # Run this if you're getting an error regarding resources
 ```
 
 ## Running the server

--- a/src/client.rs
+++ b/src/client.rs
@@ -230,17 +230,12 @@ impl GameState for MainState {
                 // This is a temporary placeholder for this functionality until we implement
                 // the video settings in Menu. 
                 if self.win_resize != 0 {
-                    if self.win_resize % 4 == 1 {
-                       x = 640;
-                       y = 480;
-                    }
-                    else if self.win_resize % 4 == 2 {
-                        x = 800;
-                        y = 600;
-                    }
-                    else if self.win_resize % 4 == 3 {
-                        x = DEFAULT_SCREEN_WIDTH;
-                        y = DEFAULT_SCREEN_HEIGHT;
+
+                    match self.win_resize % 4 {
+                        1 => { x = 640; y = 480; }
+                        2 => { x = 800; y = 480; }
+                        3 => { x = DEFAULT_SCREEN_WIDTH; y = DEFAULT_SCREEN_HEIGHT; }
+                        _ => {}
                     }
 
                     let _ = renderer.set_logical_size(x,y);
@@ -414,9 +409,6 @@ impl GameState for MainState {
                     }
                     Keycode::Num3 => {
                        self.win_resize = 3;
-                    }
-                    Keycode::Num4 => {
-                        self.win_resize = 0;
                     }
                     Keycode::LGui => {}
                     _ => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -217,7 +217,7 @@ impl GameState for MainState {
                     let new_origin_x = self.grid_view.grid_origin.x() + dx_in_pixels;
                     let new_origin_y = self.grid_view.grid_origin.y() + dy_in_pixels;
 
-                    println!("{}, {}:", new_origin_x, new_origin_y);
+                    //println!("{}, {}:", new_origin_x, new_origin_y);
 
                     if (new_origin_x > -1*(SCREEN_WIDTH as i32 + OFFSCREEN_ADJUSTMENT_X) 
                      && new_origin_x < (SCREEN_WIDTH as i32 - OFFSCREEN_ADJUSTMENT_X)
@@ -225,11 +225,6 @@ impl GameState for MainState {
                      && new_origin_y < (SCREEN_HEIGHT as i32 - OFFSCREEN_ADJUSTMENT_Y)) {
                         self.grid_view.grid_origin = self.grid_view.grid_origin.offset(dx_in_pixels, dy_in_pixels);
                     }
-
-                   // if (new_origin_x < SCREEN_WIDTH as i32 && new_origin_x > -1*SCREEN_WIDTH as i32) &&
-                   //   (new_origin_y < SCREEN_HEIGHT as i32 && new_origin_y > -1*SCREEN_HEIGHT as i32) {
-                   //     self.grid_view.grid_origin = self.grid_view.grid_origin.offset(dx_in_pixels, dy_in_pixels);
-                   // }
                 }
             }
         }
@@ -357,25 +352,20 @@ impl GameState for MainState {
                         // Zoom In
                         if self.grid_view.cell_size < ZOOM_LEVEL_MAX {
                             
-                            println!("OriginB: ({},{})", self.grid_view.grid_origin.x(), self.grid_view.grid_origin.y());
+                            println!("Origin Before: ({},{})", self.grid_view.grid_origin.x(), self.grid_view.grid_origin.y());
                             
                             let prev_zoom = self.grid_view.cell_size;
                             let next_zoom = prev_zoom+1;
 
                             self.grid_view.cell_size += 1;
 
-                            // Draw out zoom 1 and 2
-                            // Calculate distance from center for both
-                            // Calculate hypotenuse delta and apply as offset from
-                            // outter origin
-                             let new_origin_x = (self.grid_view.rows as i32);
-                             let new_origin_y = (self.grid_view.rows as i32);
-
-                             println!("OriginN: ({},{})", new_origin_x, new_origin_y);
+                            // TODO correct origin after zoom
+                            let new_origin_x = (self.grid_view.rows as i32);
+                            let new_origin_y = (self.grid_view.rows as i32);
 
                             self.grid_view.grid_origin = self.grid_view.grid_origin.offset(new_origin_x, new_origin_y);
 
-                            println!("OriginA: ({},{})\n", self.grid_view.grid_origin.x(), self.grid_view.grid_origin.y());
+                            println!("Origin After: ({},{})\n", self.grid_view.grid_origin.x(), self.grid_view.grid_origin.y());
                         }
                     }
                     Keycode::Minus | Keycode::Underscore => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -326,9 +326,9 @@ impl GameState for MainState {
                     }
                     Keycode::Minus | Keycode::Underscore => {
                         // Zoom Out
-                        if self.grid_view.cell_size > 0 {
+                        if self.grid_view.cell_size > 2 {
                             self.grid_view.cell_size -= 1;
-                        }
+                        } 
                     }
                     _ => {
                         println!("Unrecognized keycode {}", keycode);
@@ -384,6 +384,9 @@ impl GridView {
         let right  = self.grid_origin.x() + (col + 1) as i32 * self.cell_size - 1;
         let top    = self.grid_origin.y() + (row as i32)     * self.cell_size;
         let bottom = self.grid_origin.y() + (row + 1) as i32 * self.cell_size - 1;
+
+        //println!("Left: {}, Right: {}\nTop: {}, Bottom: {}\n", left, right, top, bottom);
+
         assert!(left < right);
         assert!(top < bottom);
         let rect = Rect::new(left, top, (right - left) as u32, (bottom - top) as u32);

--- a/src/client.rs
+++ b/src/client.rs
@@ -56,6 +56,7 @@ struct MainState {
     single_step:         bool,
     arrow_input:         (i32, i32),
     drag_draw:           Option<CellState>,
+    win_resize:          u8,
 }
 
 // Support non-alive/dead/bg colors
@@ -120,6 +121,7 @@ impl GameState for MainState {
             single_step:         false,
             arrow_input:         (0, 0),
             drag_draw:           None,
+            win_resize:          0,
         };
 
         // Initialize patterns
@@ -216,6 +218,36 @@ impl GameState for MainState {
                     self.uni.next();     // next generation
                     self.single_step = false;
                 }
+
+                if self.win_resize % 4 == 1 {
+                    let renderer = _ctx.renderer.window_mut().unwrap();
+                    println!("Previous Window Size: {:?}", renderer.size());
+
+                    match renderer.set_size(800, 600) {
+                        Err(x) => println!("Resizing Error: {}", x),
+                        Ok(_) => println!("Apparently it went A-OK."),
+                    }
+                }
+                else if self.win_resize % 4 == 2 {
+                    let renderer = _ctx.renderer.window_mut().unwrap();
+                    println!("Previous Window Size: {:?}", renderer.size());
+
+                    match renderer.set_size(640, 480) {
+                        Err(x) => println!("Resizing Error: {}", x),
+                        Ok(_) => println!("Apparently it went A-OK."),
+                    }
+
+                }
+                else if self.win_resize % 4 == 3 {
+                    let renderer = _ctx.renderer.window_mut().unwrap();
+                    println!("Previous Window Size: {:?}", renderer.size());
+
+                    match renderer.set_size(SCREEN_WIDTH, SCREEN_HEIGHT) {
+                        Err(x) => println!("Resizing Error: {}", x),
+                        Ok(_) => println!("Apparently it went A-OK."),
+                    }
+                }
+                self.win_resize = 0;
 
                 // Update panning
                 if self.arrow_input != (0, 0) {
@@ -361,6 +393,18 @@ impl GameState for MainState {
                     }
                     Keycode::Minus | Keycode::Underscore => {
                         adjust_zoom_level(self, ZoomDirection::ZoomOut);
+                    }
+                    Keycode::Num1 => {
+                       self.win_resize = 1;
+                    }
+                    Keycode::Num2 => {
+                       self.win_resize = 2;
+                    }
+                    Keycode::Num3 => {
+                       self.win_resize = 3;
+                    }
+                    Keycode::Num4 => {
+                        self.win_resize = 0;
                     }
                     Keycode::LGui => {}
                     _ => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -219,10 +219,10 @@ impl GameState for MainState {
 
                     //println!("{}, {}:", new_origin_x, new_origin_y);
 
-                    if (new_origin_x > -1*(SCREEN_WIDTH as i32 + OFFSCREEN_ADJUSTMENT_X) 
+                    if new_origin_x > -1*(SCREEN_WIDTH as i32 + OFFSCREEN_ADJUSTMENT_X) 
                      && new_origin_x < (SCREEN_WIDTH as i32 - OFFSCREEN_ADJUSTMENT_X)
                      && new_origin_y > -1*(SCREEN_HEIGHT as i32 + OFFSCREEN_ADJUSTMENT_Y/10) 
-                     && new_origin_y < (SCREEN_HEIGHT as i32 - OFFSCREEN_ADJUSTMENT_Y)) {
+                     && new_origin_y < (SCREEN_HEIGHT as i32 - OFFSCREEN_ADJUSTMENT_Y) {
                         self.grid_view.grid_origin = self.grid_view.grid_origin.offset(dx_in_pixels, dy_in_pixels);
                     }
                 }
@@ -354,16 +354,23 @@ impl GameState for MainState {
                             
                             println!("Origin Before: ({},{})", self.grid_view.grid_origin.x(), self.grid_view.grid_origin.y());
                             
-                            let prev_zoom = self.grid_view.cell_size;
-                            let next_zoom = prev_zoom+1;
+                            let current_cell_size = self.grid_view.cell_size as f32;
+                            let next_cell_size = (self.grid_view.cell_size + 1) as f32;
 
-                            self.grid_view.cell_size += 1;
+                            let current_cell_count_x = self.grid_view.rect.width() as f32 / current_cell_size;
+                            let current_cell_count_y = self.grid_view.rect.height() as f32 / current_cell_size;
+                            let new_cell_count_x = self.grid_view.rect.width() as f32 / next_cell_size;
+                            let new_cell_count_y = self.grid_view.rect.height() as f32 / next_cell_size;
 
-                            // TODO correct origin after zoom
-                            let new_origin_x = (self.grid_view.rows as i32);
-                            let new_origin_y = (self.grid_view.rows as i32);
+                            println!("cur {}, {}", current_cell_count_x, current_cell_count_y);
+                            println!("new {}, {}", new_cell_count_x, new_cell_count_y);
 
-                            self.grid_view.grid_origin = self.grid_view.grid_origin.offset(new_origin_x, new_origin_y);
+                            let delta_x = (current_cell_count_x - new_cell_count_x) * next_cell_size / 2.0;
+                            let delta_y = (current_cell_count_y - new_cell_count_y) * next_cell_size / 2.0;
+
+                            self.grid_view.cell_size = next_cell_size as i32;
+
+                            self.grid_view.grid_origin = self.grid_view.grid_origin.offset(-(delta_x as i32), -(delta_y as i32));
 
                             println!("Origin After: ({},{})\n", self.grid_view.grid_origin.x(), self.grid_view.grid_origin.y());
                         }
@@ -403,7 +410,7 @@ impl GameState for MainState {
 // Controls the mapping between window and game coordinates
 struct GridView {
     rect:        Rect,  // the area the game grid takes up on screen
-    cell_size:   i32,   // zoom level in window coordinates
+    cell_size:   i32,   // zoom level in window coordinates, TODO AMEEN make unsigned
     columns:     usize, // width in game coords (should match bitmap/universe width)
     rows:        usize, // height in game coords (should match bitmap/universe height)
     grid_origin: Point, // top-left corner of grid w.r.t window coords. (may be outside rect)

--- a/src/client.rs
+++ b/src/client.rs
@@ -352,27 +352,46 @@ impl GameState for MainState {
                         // Zoom In
                         if self.grid_view.cell_size < ZOOM_LEVEL_MAX {
                             
+                            println!("Window Size: ({}, {})", self.grid_view.rect.width(), self.grid_view.rect.height());
                             println!("Origin Before: ({},{})", self.grid_view.grid_origin.x(), self.grid_view.grid_origin.y());
-                            
+                            println!("Cell Size Before: {},", self.grid_view.cell_size);
+
                             let current_cell_size = self.grid_view.cell_size as f32;
                             let next_cell_size = (self.grid_view.cell_size + 1) as f32;
 
-                            let current_cell_count_x = self.grid_view.rect.width() as f32 / current_cell_size;
-                            let current_cell_count_y = self.grid_view.rect.height() as f32 / current_cell_size;
-                            let new_cell_count_x = self.grid_view.rect.width() as f32 / next_cell_size;
-                            let new_cell_count_y = self.grid_view.rect.height() as f32 / next_cell_size;
+                            // TODO change to window width
+                            // let current_cell_count_x = self.grid_view.rect.width() as f32 / current_cell_size;
+                            // let current_cell_count_y = self.grid_view.rect.height() as f32 / current_cell_size;
+                            // let new_cell_count_x = self.grid_view.rect.width() as f32 / next_cell_size;
+                            // let new_cell_count_y = self.grid_view.rect.height() as f32 / next_cell_size;
+                            //
+                            let window_center = Point::new((self.grid_view.rect.width()/2) as i32, (self.grid_view.rect.height()/2) as i32);
 
-                            println!("cur {}, {}", current_cell_count_x, current_cell_count_y);
-                            println!("new {}, {}", new_cell_count_x, new_cell_count_y);
+                            let (current_cell_count_x, current_cell_count_y) = self.grid_view.game_coords_from_window(window_center).unwrap();
 
-                            let delta_x = (current_cell_count_x - new_cell_count_x) * next_cell_size / 2.0;
-                            let delta_y = (current_cell_count_y - new_cell_count_y) * next_cell_size / 2.0;
+                            let current_cell_count_x = current_cell_count_x as f32;
+                            let current_cell_count_y = current_cell_count_y as f32;
+
+                            let delta_x = current_cell_count_x * next_cell_size - current_cell_count_x * current_cell_size;
+                            let delta_y = current_cell_count_y * next_cell_size - current_cell_count_y * current_cell_size;
+
+                            println!("current cell count: {}, {}", current_cell_count_x, current_cell_count_y);
+                            //println!("current cell count: {}, {}", current_cell_count_x, current_cell_count_y);
+                            //println!("current cell count: {}, {}", current_cell_count_x, current_cell_count_y);
+                            //println!("new cell count: {}, {}", new_cell_count_x, new_cell_count_y);
+
+                            // # of pixels to move
+                            // let delta_x = (current_cell_count_x - new_cell_count_x) * next_cell_size / 2.0;
+                            // let delta_y = (current_cell_count_y - new_cell_count_y) * next_cell_size / 2.0;
+
+                            println!("delta in win coords: {}, {}", delta_x, delta_y);
 
                             self.grid_view.cell_size = next_cell_size as i32;
 
                             self.grid_view.grid_origin = self.grid_view.grid_origin.offset(-(delta_x as i32), -(delta_y as i32));
 
                             println!("Origin After: ({},{})\n", self.grid_view.grid_origin.x(), self.grid_view.grid_origin.y());
+                            println!("Cell Size After: {},", self.grid_view.cell_size);
                         }
                     }
                     Keycode::Minus | Keycode::Underscore => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,10 +33,10 @@ enum Stage {
 struct MainState {
     small_font:          graphics::Font,
     intro_text:          graphics::Text,
-    stage:               Stage,
-    uni:                 Universe,
+    stage:               Stage,             // What state we are in (Intro/Menu Main/Generations..)
+    uni:                 Universe,          // Things alive and moving here
     first_gen_was_drawn: bool,              // the purpose of this is to inhibit gen calc until the first draw
-    grid_view:           GridView,
+    grid_view:           GridView,          // 
     color_settings:      ColorSettings,
     running:             bool,
 
@@ -46,6 +46,7 @@ struct MainState {
     drag_draw:           Option<CellState>,
 }
 
+// Support non-alive/dead/bg colors
 struct ColorSettings {
     cell_colors: BTreeMap<CellState, Color>,
     background: Color,
@@ -317,6 +318,18 @@ impl GameState for MainState {
                     Keycode::Right => {
                         self.arrow_input = ( 1, 0);
                     }
+                    Keycode::Plus | Keycode::Equals => {
+                        // Zoom In
+                        if self.grid_view.cell_size < 100 { // do we need a max
+                            self.grid_view.cell_size += 1;
+                        }
+                    }
+                    Keycode::Minus | Keycode::Underscore => {
+                        // Zoom Out
+                        if self.grid_view.cell_size > 0 {
+                            self.grid_view.cell_size -= 1;
+                        }
+                    }
                     _ => {
                         println!("Unrecognized keycode {}", keycode);
                     }
@@ -348,7 +361,7 @@ struct GridView {
     cell_size:   i32,   // zoom level in window coordinates
     columns:     usize, // width in game coords (should match bitmap/universe width)
     rows:        usize, // height in game coords (should match bitmap/universe height)
-    grid_origin: Point, // top-left corner of grid in window coords. (may be outside rect)
+    grid_origin: Point, // top-left corner of grid w.r.t window coords. (may be outside rect)
 }
 
 


### PR DESCRIPTION
I've added capabilities to zoom in and out using `+ | =` or `- | _`, respectively. Panning broke afterwards so I corrected that behavior as well. By default there will be a 100px border which will limit panning capabilities. 

I've also added rudimentary support for setting different resolutions. You can cycle through the one's present by `1 | 2 | 3`.

Finally, I updated the installation instructions to include Mac support.

It is not perfect and there are still some bugs, but this is something to get us going 😄 .